### PR TITLE
Add watch support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - **[Breaking]** Major overhaul of the angular target. The server build no longer depends on the client.
 - **[Breaking]** Update to `gulp@4` (from `gulp@3`)
-- **[Breaking]** Update to `tslint@7` (from `tslint@6`), add strciter default rules
+- **[Breaking]** Update to `tslint@7` (from `tslint@6`), add stricter default rules
 - **[Breaking]** Update signature of targetGenerators and project tasks: it only uses
   `ProjectOptions` and `Target` now, the additional options are embedded in those two objects.
 - **[Breaking]** Remove `:install`, `:instal:npm` and `:install:typings`. Use the `prepare` script in
@@ -12,6 +12,7 @@
 - Implement end-to-end tests
 - Enable `emitDecoratorMetadata` in default typescript options.
 - Allow configuration of `:lint` with the `tslintOptions` property of the project configuration.
+- Add `<target>:watch` tasks for incremental builds.
 
 ## TODO:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demurgos-web-build-tools",
-  "version": "0.13.0-alpha.4",
+  "version": "0.13.0-alpha.5",
   "description": "Gulp tasks generator for standard web projects.",
   "private": false,
   "main": "dist/lib/lib/index.js",

--- a/src/lib/task-generators/build-typescript.ts
+++ b/src/lib/task-generators/build-typescript.ts
@@ -1,3 +1,4 @@
+import {FSWatcher} from "fs";
 import {Gulp, TaskFunction} from "gulp";
 import gulpSourceMaps = require("gulp-sourcemaps");
 import gulpTypescript = require("gulp-typescript");
@@ -141,7 +142,7 @@ function getReporter(strict: boolean = true): CompleteReporter {
   return reporter;
 }
 
-export function registerTask(gulp: Gulp, targetName: string, options: Options): TaskFunction {
+export function generateTask(gulp: Gulp, options: Options): TaskFunction {
   const sources: Sources = getSources(options);
   const compilerOptions: CompilerJsonOptions = assign({}, DEV_TSC_OPTIONS, options.compilerOptions);
   const reporter: CompleteReporter = getReporter(options.strict);
@@ -161,10 +162,14 @@ export function registerTask(gulp: Gulp, targetName: string, options: Options): 
         .pipe(gulp.dest(options.buildDir))
     ]);
   };
-
-  gulp.task(`${targetName}:build:scripts`, task);
-
+  task.displayName = `_build:scripts`;
   return task;
 }
 
-export default registerTask;
+export function watch(gulp: Gulp, options: Options): FSWatcher {
+  const buildTask: TaskFunction = generateTask(gulp, options);
+  const sources: Sources = getSources(options);
+  return gulp.watch(sources.sources, {cwd: sources.baseDir}, buildTask);
+}
+
+export default generateTask;

--- a/src/lib/task-generators/copy.ts
+++ b/src/lib/task-generators/copy.ts
@@ -1,6 +1,6 @@
+import {FSWatcher} from "fs";
 import {Gulp, TaskFunction} from "gulp";
 import {Minimatch} from "minimatch";
-
 import {asString, join} from "../utils/matcher";
 
 export interface Options {
@@ -12,7 +12,7 @@ export interface Options {
   /**
    * Base-directory for copy
    */
-  from: string;
+    from: string;
 
   /**
    * Target directory
@@ -37,7 +37,15 @@ export function copy(gulp: Gulp, options: Options): NodeJS.ReadableStream {
  * Generate a task to copy files from one directory to an other.
  */
 export function generateTask(gulp: Gulp, options: Options): TaskFunction {
-  return function (): NodeJS.ReadableStream {
+  const task: TaskFunction = function (): NodeJS.ReadableStream {
     return copy(gulp, options);
   };
+  task.displayName = `_build:copy`;
+  return task;
+}
+
+export function watch(gulp: Gulp, options: Options): FSWatcher {
+  const buildTask: TaskFunction = generateTask(gulp, options);
+  const sources: string[] = getSources(options);
+  return gulp.watch(sources, {cwd: options.from}, buildTask);
 }

--- a/src/lib/task-generators/pug.ts
+++ b/src/lib/task-generators/pug.ts
@@ -1,7 +1,7 @@
 import Bluebird = require("bluebird");
+import {FSWatcher} from "fs";
 import {Gulp, TaskFunction} from "gulp";
 import {Minimatch} from "minimatch";
-import {posix as path} from "path";
 import gulpPug = require("gulp-pug");
 import {asString, join} from "../utils/matcher";
 
@@ -14,7 +14,7 @@ export interface Options {
   /**
    * Base-directory for copy
    */
-  from: string;
+    from: string;
 
   /**
    * Target directory
@@ -47,7 +47,15 @@ export function buildPug(gulp: Gulp, options: Options): NodeJS.ReadableStream {
  * Generate a task to build pug files
  */
 export function generateTask(gulp: Gulp, options: Options): TaskFunction {
-  return function (): NodeJS.ReadableStream {
+  const task: TaskFunction = function (): NodeJS.ReadableStream {
     return buildPug(gulp, options);
   };
+  task.displayName = `_build:pug`;
+  return task;
+}
+
+export function watch(gulp: Gulp, options: Options): FSWatcher {
+  const buildTask: TaskFunction = generateTask(gulp, options);
+  const sources: string[] = getSources(options);
+  return gulp.watch(sources, {cwd: options.from}, buildTask);
 }

--- a/src/lib/task-generators/sass.ts
+++ b/src/lib/task-generators/sass.ts
@@ -1,10 +1,9 @@
 import Bluebird = require("bluebird");
+import {FSWatcher} from "fs";
 import {Gulp, TaskFunction} from "gulp";
 import {Minimatch} from "minimatch";
-import {posix as path} from "path";
 import gulpSass = require("gulp-sass");
 import gulpSourceMaps = require("gulp-sourcemaps");
-
 import {asString, join} from "../utils/matcher";
 
 export interface Options {
@@ -27,7 +26,7 @@ export interface Options {
    * gulp-sass options
    */
   sassOptions?: {
-      outputStyle?: "compressed" | string;
+    outputStyle?: "compressed" | string;
   };
 }
 
@@ -51,7 +50,15 @@ export function buildSass(gulp: Gulp, options: Options): NodeJS.ReadableStream {
  * Generate a task to build pug files
  */
 export function generateTask(gulp: Gulp, options: Options): TaskFunction {
-  return function (): NodeJS.ReadableStream {
+  const task: TaskFunction = function (): NodeJS.ReadableStream {
     return buildSass(gulp, options);
   };
+  task.displayName = "_build:sass";
+  return task;
+}
+
+export function watch(gulp: Gulp, options: Options): FSWatcher {
+  const buildTask: TaskFunction = generateTask(gulp, options);
+  const sources: string[] = getSources(options);
+  return gulp.watch(sources, {cwd: options.from}, buildTask);
 }

--- a/src/lib/task-generators/tsconfig-json.ts
+++ b/src/lib/task-generators/tsconfig-json.ts
@@ -73,7 +73,7 @@ export function generateTask(gulp: Gulp, options: Options): TaskFunction {
 
   const tsconfigPath: string = path.join(options.tsconfigPath);
 
-  const task: TaskFunction =  function () {
+  const task: TaskFunction = function () {
     return writeJsonFile(tsconfigPath, tsconfigData);
   };
 


### PR DESCRIPTION
This PR adds support for `watch` tasks.
It is granular for pug, sass and copy tasks. The scripts and webpack tasks still need some improvement since a change triggers a full rebuild.

This closes #7.