### PR TITLE
Rename `project.tslintOptions` parameter to `projects.tslint`

### DIFF
--- a/src/lib/config/config.ts
+++ b/src/lib/config/config.ts
@@ -40,19 +40,31 @@ export interface ProjectOptions {
   srcDir: string;
 
   /**
-   * Path to the tslint.json file, relative to `root`
+   * Tslint configuration
    */
-  tslintJson?: string;
+  tslint?: {
+    /**
+     * Path to the tslint.json file, relative to `root`
+     */
+    tslintJson?: string;
 
-  tslintOptions?: {
+    /**
+     * Override default configuration
+     */
     configuration?: {
       rules?: {}
     },
+
     formatter?: "verbose" | string;
+
     /**
      * The files to lint, relative to `root`
      */
     files?: string[];
+
+    /**
+     * Instance of tslint to use
+     */
     tslint?: any;
   };
 }
@@ -290,7 +302,10 @@ export const DEFAULT_PROJECT_OPTIONS: ProjectOptions = {
   packageJson: "package.json",
   buildDir: "build",
   distDir: "dist",
-  srcDir: "src"
+  srcDir: "src",
+  tslint: {
+    tslintJson: "tslint.json"
+  }
 };
 
 /**

--- a/src/lib/project-tasks/lint.ts
+++ b/src/lib/project-tasks/lint.ts
@@ -29,8 +29,8 @@ export function getSources(project: ProjectOptions): Sources {
   const sources: string[] = [];
   let patterns: string[];
 
-  if (project.tslintOptions !== undefined && project.tslintOptions.files !== undefined) {
-    patterns = project.tslintOptions.files;
+  if (project.tslint !== undefined && project.tslint.files !== undefined) {
+    patterns = project.tslint.files;
   } else {
     patterns = [path.join(project.srcDir, "**/*.ts")];
   }
@@ -50,7 +50,7 @@ export function registerTask(gulp: Gulp, project: ProjectOptions) {
     configuration: defaultTslintConfig,
     formatter: "verbose",
     tslint: tslint
-  }, project.tslintOptions);
+  }, project.tslint);
 
   const sources: Sources = getSources(project);
 

--- a/src/lib/project-tasks/tslint-json.ts
+++ b/src/lib/project-tasks/tslint-json.ts
@@ -9,7 +9,12 @@ import defaultTslintConfig from "../config/tslint";
 import {writeJsonFile} from "../utils/project";
 
 export function generateTask(gulp: Gulp, project: ProjectOptions): TaskFunction {
-  const relativePath: string = project.tslintJson === undefined ? "tslint.json" : project.tslintJson;
+  let relativePath: string;
+  if (project.tslint !== undefined && project.tslint.tslintJson !== undefined) {
+    relativePath = project.tslint.tslintJson;
+  } else {
+    relativePath = "tslint.json";
+  }
   const absolutePath: string = path.join(project.root, relativePath);
 
   return function () {


### PR DESCRIPTION
This PR normalizes the name of the property used to configure _tslint_ to match the other names. (from tslintOptions to tslint).

This also moves `project.tslintJson` to `project.tslint.tslintJson`