### PR TITLE
Add experimental lib dist for deep require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Review the organization of the build targets
 - Use `displayName` on task functions, instead of separate `generateTaskName` functions.
 
+## 0.15.0-beta.3 (2017-08-10)
+
+- **[Feature]** Add experimental library distribution supporting deep requires.
+
 ## 0.15.0-beta.2 (2017-08-10)
 
 - **[Fix]** Default to CommonJS for project tsconfig.json

--- a/src/e2e/node-lib/node-lib.spec.ts
+++ b/src/e2e/node-lib/node-lib.spec.ts
@@ -44,7 +44,7 @@ describe("Project node-lib", function (this: Mocha.ISuiteCallbackContext) {
     });
 
     it("should output runnable typescript files", async function (this: Mocha.ITestCallbackContext): Promise<void> {
-      const result: ExecFileResult = await execFile("node", ["build/lib/lib/hello-world.js"], {cwd: PROJECT_ROOT});
+      const result: ExecFileResult = await execFile("node", ["build/lib/hello-world.js"], {cwd: PROJECT_ROOT});
 
       const actualOutput: string = result.stdout.toString("utf8");
       const expectedOutput: string = "Hello, World!\n";
@@ -60,7 +60,7 @@ describe("Project node-lib", function (this: Mocha.ISuiteCallbackContext) {
     });
 
     it("should output runnable typescript files", async function (this: Mocha.ITestCallbackContext): Promise<void> {
-      const result: ExecFileResult = await execFile("node", ["dist/lib/lib/hello-world.js"], {cwd: PROJECT_ROOT});
+      const result: ExecFileResult = await execFile("node", ["dist/lib/hello-world.js"], {cwd: PROJECT_ROOT});
 
       const actualOutput: string = result.stdout.toString("utf8");
       const expectedOutput: string = "Hello, World!\n";

--- a/src/e2e/node-lib/project/gulpfile.js
+++ b/src/e2e/node-lib/project/gulpfile.js
@@ -24,7 +24,7 @@ const libTarget = Object.assign(
       },
       typescript: typescript,
       strict: true,
-      tsconfigJson: ["lib/tsconfig.json"]
+      tsconfigJson: ["tsconfig.json"]
     }
   }
 );

--- a/src/e2e/node-lib/test-resources/lib._tsconfig.json
+++ b/src/e2e/node-lib/test-resources/lib._tsconfig.json
@@ -43,7 +43,7 @@
     "outDir": "../../build/lib",
     "preserveConstEnums": true,
     "removeComments": false,
-    "rootDir": "..",
+    "rootDir": "",
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
@@ -54,15 +54,11 @@
     "traceResolution": false,
     "typeRoots": [
       "../custom-typings",
-      "../../typings/globals",
-      "../../typings/modules",
       "../../node_modules/@types"
     ]
   },
   "include": [
     "**/*.ts"
   ],
-  "exclude": [
-    "../**/*.spec.ts"
-  ]
+  "exclude": []
 }

--- a/src/lib/targets.ts
+++ b/src/lib/targets.ts
@@ -21,14 +21,19 @@ export interface Target {
   targetDir?: string;
 
   /**
+   * Source directory for this target, relative to `project.srcDir`.
+   */
+  srcDir?: string;
+
+  /**
    * List of minimatch glob patterns matching the Typescript scripts, relative
-   * to `project.srcDir`.
+   * to `target.srcDir`.
    */
   scripts: string[];
 
   /**
    * List of directories where Typescript should search for declarations,
-   * relative to `project.srcDir`.
+   * relative to `target.srcDir`.
    */
   typeRoots: string[];
 
@@ -69,6 +74,8 @@ export interface NodeTarget extends Target {
    * relative to `project.srcDir`.
    */
   mainModule?: string | null;
+
+  distPackage?: boolean;
 }
 
 export interface TestTarget extends NodeTarget {
@@ -100,16 +107,17 @@ export interface WebpackTarget extends Target {
 }
 
 /**
- * Preconfigured "node" configuration to develop a node library.
+ * Preconfigured "node" configuration to develop a simple node library.
  * It uses Typescript and Typings.
  */
 export const LIB_TARGET: NodeTarget = {
   name: "lib",
-  scripts: ["lib/**/*.ts", "!**/*.spec.ts"],
-  typeRoots: ["custom-typings", "../typings/globals", "../typings/modules", "../node_modules/@types"],
-  mainModule: "lib/index",
+  srcDir: "./lib",
+  scripts: ["**/*.ts"],
+  typeRoots: ["../custom-typings", "../../node_modules/@types"],
+  mainModule: "index",
   typescript: {
-    tsconfigJson: ["lib/tsconfig.json"],
+    tsconfigJson: ["tsconfig.json"],
   },
 };
 

--- a/src/lib/utils/project.ts
+++ b/src/lib/utils/project.ts
@@ -37,9 +37,12 @@ export async function release(version: string, locations: Project): Promise<void
 
 export interface PackageJson {
   version: string;
+  main: string;
+  types: string;
+  module?: string;
 }
 
-export async function readJsonFile<T>(filePath: string): Promise<T> {
+export async function readJsonFile<T = any>(filePath: string): Promise<T> {
   return JSON.parse(await readText(filePath));
 }
 


### PR DESCRIPTION
To support deep require, you have to set the `distPackage`
option of `NodeTarget` to `true`.