### PR TITLE
Release v0.15.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 - Review the organization of the build targets
 - Use `displayName` on task functions, instead of separate `generateTaskName` functions.
 
-## 0.15.0-beta.3 (2017-08-10)
+## 0.15.0-beta.3 (2017-08-11)
 
+- **[Breaking]** Update default lib target to use target-specific `srcDir`.
+- **[Feature]** Allow to complete `srcDir` in target.
 - **[Feature]** Add experimental library distribution supporting deep requires.
 
 ## 0.15.0-beta.2 (2017-08-10)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "demurgos-web-build-tools",
-  "version": "0.15.0-beta.2",
+  "version": "0.15.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demurgos-web-build-tools",
-  "version": "0.15.0-beta.2",
+  "version": "0.15.0-beta.3",
   "description": "Gulp tasks generator for standard web projects.",
   "private": false,
   "main": "dist/lib/lib/index.js",


### PR DESCRIPTION
- **[Breaking]** Update default lib target to use target-specific `srcDir`.
- **[Feature]** Allow to complete `srcDir` in target.
- **[Feature]** Add experimental library distribution supporting deep requires.