### PR TITLE
Fix continuous deployment for releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- **[Fix]** Fix support of releases from Continuous Deployment using Travis.
+
 ## 0.15.0 (2017-10-18)
 
 - **[Fix]** Add error handling for git deployment.

--- a/tools/continuous-deployment.travis.sh
+++ b/tools/continuous-deployment.travis.sh
@@ -27,74 +27,105 @@ set -e
 # Space out deploys by at least this interval, 1day == 86400sec
 DEPLOY_INTERVAL=600
 # Deploy only on merge commit to this branch
-SOURCE_BRANCH="master"
+DEPLOYMENT_BRANCH="dev2"
 # Id in the name of the key and iv files
 TRAVIS_ENCRYPTION_ID="fa98f77d113d"
 # Build id used for the publication of pre-release builds to `npm`
 BUILD_ID=${TRAVIS_BUILD_NUMBER}
+# Branch name or tag name
 GIT_HEAD_BRANCH=${TRAVIS_BRANCH}
+# If this is build for a tag, name of the tag (empty string otherwise)
 GIT_HEAD_TAG=${TRAVIS_TAG}
+# Possible values: "branch", "tag", "pr"
+CI_BUILD_TYPE=`[[ ${TRAVIS_PULL_REQUEST} == "true" ]] && echo "pr" || [ -n "${TRAVIS_TAG}" ] && echo "tag" || echo "branch"`
 
 ###############################################################################
-# Check if we should deploy                                                   #
+# Get information about the current build                                     #
 ###############################################################################
-# Pull requests shouldn't try to deploy
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-    echo "Skipping deployment: This is a Pull Request build."
-    exit 0
-fi
 
-# Only commits to the source branch should deploy
-if [ "$GIT_HEAD_BRANCH" != "$SOURCE_BRANCH" ]; then
-    echo "Skipping deployment: Not on the source branch $SOURCE_BRANCH."
-    exit 0
+# If the current build is a tag build, check if the corresponding tag is on the deployment branch
+IS_GIT_HEAD_TAG_ON_DEPLOYMENT_BRANCH="false"
+if [[ "${CI_BUILD_TYPE}" == "tag" ]]; then
+  # Revert `--single-branch` (caused by `--depth`)
+  git config remote.origin.fetch refs/heads/*:refs/remotes/origin/*
+  # Fetch all (TODO: Only fetch the last commits of the deployment branch)
+  git fetch --quiet --unshallow --tags
+  echo "foo"
+  # List the tags on the deployment branch (ignore errors), use grep to perform an exact match and test if the match returns the tag
+  GIT_HEAD_TAG_ON_DEPLOYMENT_BRANCH_MATCH=`(git tag --merged "origin/${DEPLOYMENT_BRANCH}" 2> /dev/null || true) | grep --fixed-strings --line-regexp "${GIT_HEAD_TAG}"`
+  echo $GIT_HEAD_TAG_ON_DEPLOYMENT_BRANCH_MATCH
+  IS_GIT_HEAD_TAG_ON_DEPLOYMENT_BRANCH=`[ -z "${GIT_HEAD_TAG_ON_DEPLOYMENT_BRANCH_MATCH}" ] && echo "false" || echo "true"`
 fi
-
 # Time of the latest commit in seconds since UNIX epoch
 GIT_HEAD_TIME=`git log -1 --pretty=format:%ct`
 # ISO date or empty string: time of last modification of the pre-release build on npm
 NPM_NEXT_DATE=`npm view demurgos-web-build-tools@next time.modified`
+# Parse the ISO date to a timestamp if we got a non-empty result (default is 0 - UNIX epoch)
+NPM_NEXT_TIME=`[ -z "${GIT_HEAD_TAG_ON_DEPLOYMENT_BRANCH_MATCH}" ] && echo "0" || date -d ${NPM_NEXT_DATE} "+%s"`
+# Hash of the git head for the pre-release build on npm
+NPM_NEXT_GIT_HEAD=`npm view demurgos-web-build-tools@next gitHead`
 # Version of the latest release
 NPM_LATEST_VERSION=`npm view demurgos-web-build-tools@next version`
 # Local version of the package
 NPM_LOCAL_VERSION=`jq .version < package.json`
-# Release type: "release" or "pre-release".
-NPM_RELEASE_TYPE="pre-release"
 
-# Release if there is a git tag matching the version in `package.json` (pre-release by default).
-if [[ $GIT_HEAD_TAG == "v$NPM_LOCAL_VERSION" ]]; then
-  NPM_RELEASE_TYPE="release"
-else
-  NPM_RELEASE_TYPE="pre-release"
-  if [ -n "$NPM_NEXT_DATE" ]; then
-    # Parse the ISO date to a timestamp if we got a non-empty result
-    NPM_NEXT_TIME=`date -d ${NPM_NEXT_DATE} "+%s"`
+echo "ci: build id: $BUILD_ID"
+echo "ci: build type: $CI_BUILD_TYPE"
+echo "git: branch: $GIT_HEAD_BRANCH"
+echo "git: tag: $GIT_HEAD_TAG"
+echo "git: is tag on deployment branch ($DEPLOYMENT_BRANCH): $IS_GIT_HEAD_TAG_ON_DEPLOYMENT_BRANCH"
+echo "npm: @next modification date: $NPM_NEXT_DATE"
+echo "npm: @latest version: $NPM_LATEST_VERSION"
+echo "npm: local version: $NPM_LOCAL_VERSION"
+echo ""
+
+###############################################################################
+# Check if we should deploy                                                   #
+###############################################################################
+
+
+case ${CI_BUILD_TYPE} in
+  "pr")
+    echo "Skipping deployment: This is only a Pull Request."
+    exit 0
+    ;;
+  "tag")
+    # Only commits to the source branch should deploy
+    if [ "$IS_GIT_HEAD_TAG_ON_DEPLOYMENT_BRANCH" != "true" ]; then
+      echo "Skipping deployment: Current tag $GIT_HEAD_TAG is not on the deployment branch $DEPLOYMENT_BRANCH."
+      exit 0
+    fi
+    # Release if there is a git tag matching the version in `package.json` (pre-release by default).
+    if [[ ${GIT_HEAD_TAG} != "v$NPM_LOCAL_VERSION" ]]; then
+      echo "Skipping deployment: Tag ${GIT_HEAD_TAG} is not v$NPM_LOCAL_VERSION."
+      exit 0
+    fi
+    ;;
+  "branch")
+    # Only commits to the source branch should deploy
+    if [ "$GIT_HEAD_BRANCH" != "$DEPLOYMENT_BRANCH" ]; then
+        echo "Skipping deployment: Not on the deployment branch $DEPLOYMENT_BRANCH."
+        exit 0
+    fi
     if (( ${GIT_HEAD_TIME} - ${NPM_NEXT_TIME} < ${DEPLOY_INTERVAL})); then
       # The last version was published long enough before the current commit
       echo "Skipping deployment: Latest deployment occurred less than $DEPLOY_INTERVAL seconds ago."
       exit 0
     fi
-  fi
-fi
+    ;;
+esac
 
 ###############################################################################
 # Deployment info                                                             #
 ###############################################################################
 
 echo "+------------------------------------------------------------+"
-if [[ ${NPM_RELEASE_TYPE} == "release" ]]; then
+if [[ ${CI_BUILD_TYPE} == "tag" ]]; then
   echo "| Deploying release to npm and documentation to gh-pages     |"
 else
   echo "| Deploying pre-release to npm and documentation to gh-pages |"
 fi
 echo "+------------------------------------------------------------+"
-echo "git: branch: $GIT_HEAD_BRANCH"
-echo "git: tag: $GIT_HEAD_TAG"
-echo "npm: @next modifification date: $NPM_NEXT_DATE"
-echo "npm: @latest version: $NPM_LATEST_VERSION"
-echo "npm: local version: $NPM_LOCAL_VERSION"
-echo "ci: build id: $BUILD_ID"
-echo ""
 echo ""
 
 ###############################################################################
@@ -102,7 +133,7 @@ echo ""
 ###############################################################################
 
 echo "Deploying to npm..."
-if [[ ${NPM_RELEASE_TYPE} == "release" ]]; then
+if [[ ${CI_BUILD_TYPE} == "tag" ]]; then
   gulp lib:dist:publish
 else
   gulp lib:dist:publish --dev-dist ${BUILD_ID}


### PR DESCRIPTION
This commit improves the continuous deployment by checking if
the tag is on the master branch and displaying more information
before skipping deployment.