### PR TITLE
Disable experimental support for `*.mjs` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- **[Fix]** Disable experimental support for `*.mjs` by default.
+
 ## 0.15.1 (2017-10-19)
 
 - **[Feature]** Add experimental support for `*.mjs` files

--- a/src/lib/options/typescript.ts
+++ b/src/lib/options/typescript.ts
@@ -52,7 +52,7 @@ export interface TypescriptOptions {
    * - `Mjs`: Enforce `es2015` modules and emit `*.mjs` files.
    * - `Both`: Emit both `*.js` files using the compiler options and `*.mjs` using `es2015`.
    *
-   * Default: `Both`
+   * Default: `Js`
    */
   outModules?: OutModules;
 }
@@ -110,7 +110,7 @@ export interface CompleteTypescriptOptions extends TypescriptOptions {
 export const DEFAULT_PROJECT_TS_OPTIONS: TypescriptOptions = {
   compilerOptions: DEFAULT_PROJECT_TSC_OPTIONS,
   tsconfigJson: ["tsconfig.json"],
-  outModules: OutModules.Both,
+  outModules: OutModules.Js,
 };
 
 export function mergeTypescriptOptions(

--- a/src/lib/targets/_base.ts
+++ b/src/lib/targets/_base.ts
@@ -163,7 +163,7 @@ export interface TargetBase {
    * - `Mjs`: Enforce `es2015` modules and emit `*.mjs` files.
    * - `Both`: Emit both `*.js` files using the compiler options and `*.mjs` using `es2015`.
    *
-   * Default: `Both`
+   * Default: `Js`
    */
   outModules?: OutModules;
 
@@ -273,7 +273,7 @@ export function resolveTargetBase(target: TargetBase): ResolvedTargetBase {
 
   const tscOptions: CompilerOptionsJson = mergeTscOptionsJson(DEV_TSC_OPTIONS, target.tscOptions);
 
-  const outModules: OutModules = target.outModules !== undefined ? target.outModules : OutModules.Both;
+  const outModules: OutModules = target.outModules !== undefined ? target.outModules : OutModules.Js;
 
   const tsconfigJson: AbsPosixPath | null = target.tsconfigJson !== undefined ?
     (target.tsconfigJson !== null ? posixPath.join(project.absRoot, target.tsconfigJson) : null) :

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "allowJs": true,
+    "allowJs": false,
     "allowSyntheticDefaultImports": false,
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,


### PR DESCRIPTION
Native support for ESM is not stable enough yet to enable `*.mjs`
emission by default.