### PR TITLE
Restore watch mode support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+- **[Feature]** Add support for watch mode for library targets.
 - **[Fix]** Disable experimental support for `*.mjs` by default.
 - **[Fix]** Do not emit duplicate TS errors
 

--- a/src/lib/options/copy.ts
+++ b/src/lib/options/copy.ts
@@ -22,7 +22,7 @@ export interface CopyOptions {
   /**
    * Name of the copy operation.
    * It will be used for the name of the task: `<targetName>:build:copy:<copyName>`.
-   * If youd do not define it, it will be "anonymous" and will only
+   * If you do not define it, it will be "anonymous" and will only
    * be called by `<targetName>:build:copy`
    */
   name?: string;

--- a/src/lib/target-tasks/build-typescript.ts
+++ b/src/lib/target-tasks/build-typescript.ts
@@ -97,8 +97,14 @@ export function getBuildTypescriptTask(gulp: Gulp, options: TypescriptConfig): T
   return task;
 }
 
+export function getBuildTypescriptWatchTask(gulp: Gulp, options: TypescriptConfig): () => FSWatcher {
+  return (): FSWatcher => {
+    const buildTask: TaskFunction = getBuildTypescriptTask(gulp, options);
+    const resolved: ResolvedTsLocations = resolveTsLocations(options);
+    return gulp.watch(resolved.absScripts, {cwd: options.srcDir}, buildTask) as FSWatcher;
+  };
+}
+
 export function getBuildTypescriptWatcher(gulp: Gulp, options: TypescriptConfig): FSWatcher {
-  const buildTask: TaskFunction = getBuildTypescriptTask(gulp, options);
-  const resolved: ResolvedTsLocations = resolveTsLocations(options);
-  return gulp.watch(resolved.absScripts, {cwd: options.srcDir}, buildTask) as FSWatcher;
+  return getBuildTypescriptWatchTask(gulp, options)();
 }

--- a/src/lib/task-generators/copy.ts
+++ b/src/lib/task-generators/copy.ts
@@ -13,7 +13,7 @@ export interface Options {
   /**
    * Base-directory for copy
    */
-    from: string;
+  from: string;
 
   /**
    * Target directory
@@ -41,7 +41,7 @@ export function generateTask(gulp: Gulp, options: Options): TaskFunction {
   const task: TaskFunction = function (): NodeJS.ReadableStream {
     return copy(gulp, options);
   };
-  task.displayName = "_build:copy";
+  task.displayName = "_copy";
   return task;
 }
 


### PR DESCRIPTION
Watch mode support was lost with the update to the new-style targets.
This commit restores support for watch mode for libraries.
At the moment, it guarantees support for Typescript incremental
compilation and file copies.